### PR TITLE
Documenting vers resource and version type

### DIFF
--- a/docs/data_types.md
+++ b/docs/data_types.md
@@ -7,3 +7,28 @@
 | Length | 0      | 1    | unsigned int | The number of bytes in the string |
 | String | 1      | N    | byte         | The characters of the string      |
 
+
+## Version
+
+| Field                   | Bit Offset | Bits | Type         |
+|-------------------------|-----------:|-----:|--------------|
+| Major (tens)            |      28    |  4   | unsigned BCD |
+| Major (ones)            |      24    |  4   | unsigned BCD |
+| Minor                   |      20    |  4   | unsigned BCD |
+| Bugfix                  |      16    |  4   | unsigned BCD |
+| [Stage](#version-stage) |      13    |  3   | unsigned int |
+| Build (thousands)       |      12    |  1   | unsigned BCD |
+| Build (hundreds)        |       8    |  4   | unsigned BCD |
+| Build (tens)            |       4    |  4   | unsigned BCD |
+| Build (ones)            |       0    |  4   | unsigned BCD |
+
+### Version Stage
+
+| Value | Description |
+|------:|-------------|
+| 0     | Undefined   |
+| 1     | Alpha       |
+| 2     | Beta        |
+| 3     | Release     |
+| 4     | Undefined   |
+| 5-7   | Undefined   |

--- a/docs/resource_types.md
+++ b/docs/resource_types.md
@@ -692,6 +692,26 @@ Each resource type is identified by a four character ascii code.
 - **extensions** .vim, .glb, .vi, .ctl, .ctt, .vit, .gbl
 - **file types** LVCC, LVIN
 
+| Field    | Offset   | Size  | Type         | Description                                 |
+|----------|---------:|------:|--------------|---------------------------------------------|
+| Version  | 0        | 4     | unsigned int | LabVIEW [Version](data_types.md#version)    |
+| Language | 4        | 2     | unsigned int | [Language](#version-language)               |
+| Text     | 6        | L + 1 |[Byte prefixed string](data_types.md#bytes-prefixed-string) |
+| Name     | 6 + L +1 | L + 1 |[Byte prefixed string](data_types.md#bytes-prefixed-string) |
+
+#### Version Language
+
+| Language | Value |
+|----------|------:|
+| English  |   0   |
+| French   |   1   |
+| German   |   3   |
+| Japanese |  14   |
+| Korean   |  23   |
+| Chinese  |  33   |
+
+**Note** The language codes seem to come from the old Macintosh [Script.h](https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/Headers/Script.h) header file.
+No other languages other than the ones above have been found to be used.
 
 ## Non-VI types
 


### PR DESCRIPTION
Adding documentation for both the 'vers' resource and the version data type. This closes #1 